### PR TITLE
Fix for archived directories (Archive | Directory)

### DIFF
--- a/EzSmb/NodeFactory.cs
+++ b/EzSmb/NodeFactory.cs
@@ -112,7 +112,7 @@ namespace EzSmb
 
             var pathSet = PathSet.Parse(fullPath);
 
-            if (basicInfo.FileAttributes == SMBLibrary.FileAttributes.Directory)
+            if (basicInfo.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
             {
                 // Folder
                 var result = NodeFactory.InnerGet(
@@ -161,7 +161,7 @@ namespace EzSmb
 
             var pathSet = PathSet.Parse($@"{parentNode.FullPath}\{info.FileName}");
 
-            if (info.FileAttributes == SMBLibrary.FileAttributes.Directory)
+            if (info.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
             {
                 // Folder
                 var result = NodeFactory.InnerGet(
@@ -210,7 +210,7 @@ namespace EzSmb
 
             var pathSet = PathSet.Parse($@"{parentNode.FullPath}\{info.FileName}");
 
-            if (info.ExtFileAttributes == ExtendedFileAttributes.Directory)
+            if (info.ExtFileAttributes.HasFlag(ExtendedFileAttributes.Directory))
             {
                 // Folder
                 var result = NodeFactory.InnerGet(

--- a/EzSmb/Transports/Shares/Smb1Share.cs
+++ b/EzSmb/Transports/Shares/Smb1Share.cs
@@ -90,7 +90,7 @@ namespace EzSmb.Transports.Shares
                 foreach (FindFileDirectoryInfo info in infos)
                 {
                     if (
-                        info.ExtFileAttributes == ExtendedFileAttributes.Directory
+                        info.ExtFileAttributes.HasFlag(ExtendedFileAttributes.Directory)
                         && (
                             info.FileName == "."
                             || info.FileName == ".."

--- a/EzSmb/Transports/Shares/Smb2Share.cs
+++ b/EzSmb/Transports/Shares/Smb2Share.cs
@@ -75,7 +75,7 @@ namespace EzSmb.Transports.Shares
                 foreach (FileDirectoryInformation info in infos)
                 {
                     if (
-                        info.FileAttributes == FileAttributes.Directory
+                        info.FileAttributes.HasFlag(FileAttributes.Directory)
                         && (
                             info.FileName == "."
                             || info.FileName == ".."


### PR DESCRIPTION
Archived directories were treated as files and special directories like '.' were not filtered out