### PR TITLE
added NTStatus codes to error messages

### DIFF
--- a/EzSmb/Streams/ReaderStream.cs
+++ b/EzSmb/Streams/ReaderStream.cs
@@ -387,8 +387,8 @@ namespace EzSmb.Streams
                         && status != NTStatus.STATUS_END_OF_FILE
                     )
                     {
-                        exception = new IOException("File Reading Failed.");
-                        this.AddError("ReadStream", $"File Reading Failed.");
+                        exception = new IOException("File Reading Failed. NTStatus: {status}");
+                        this.AddError("ReadStream", $"File Reading Failed. NTStatus: {status}");
 
                         break;
                     }

--- a/EzSmb/Transports/Connection.cs
+++ b/EzSmb/Transports/Connection.cs
@@ -285,7 +285,7 @@ namespace EzSmb.Transports
             var names = this._client.ListShares(out var status);
             if (status != NTStatus.STATUS_SUCCESS)
             {
-                this.AddError("GetList", $"Share List Query Failed: {this._pathSet.Share}");
+                this.AddError("GetList", $"Share List Query Failed: {this._pathSet.Share}, NTStatus: {status}");
 
                 return null;
             }

--- a/EzSmb/Transports/Shares/Bases/ShareBase.cs
+++ b/EzSmb/Transports/Shares/Bases/ShareBase.cs
@@ -220,7 +220,7 @@ namespace EzSmb.Transports.Shares.Bases
 
             if (status != NTStatus.STATUS_SUCCESS)
             {
-                this.AddError("CreateNode", $"Basic Infomation Query Failed: {pathSet.FullPath}");
+                this.AddError("CreateNode", $"Basic Infomation Query Failed: {pathSet.FullPath}, NTStatus: {status}");
 
                 return null;
             }
@@ -301,7 +301,7 @@ namespace EzSmb.Transports.Shares.Bases
                 )
                 {
                     stream.Dispose();
-                    this.AddError("ReadStream", $"File Reading Failed.");
+                    this.AddError("ReadStream", $"File Reading Failed. NTStatus: {status}");
 
                     return null;
                 }
@@ -391,7 +391,7 @@ namespace EzSmb.Transports.Shares.Bases
 
                 if (status != NTStatus.STATUS_SUCCESS)
                 {
-                    this.AddError("WriteStream", $"File Writing Failed.");
+                    this.AddError("WriteStream", $"File Writing Failed. NTStatus: {status}");
 
                     return false;
                 }


### PR DESCRIPTION
I currently have the issue that I don't always get the NTStatus code back when an error occurs which makes debugging difficult. For example from my logfile:
2022-06-30 12:45:58,784 [15] FATAL *censored* SmbErrorException: 12:44:58.511: [EzSmb.Transports.Shares.Smb2Share.WriteStream] File Writing Failed.
Therefore I have added them in a few places.